### PR TITLE
add 0.3.0 nodejs express repo config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@ Kill the server with `^C`
 
 ## Now appsify the code
 
-In the root of the application run
+1. Add the Node.js Express 0.3.0 repository to your appsody CLI
+   * `appsody repo add appsodyhub030 https://github.com/appsody/stacks/releases/download/nodejs-express-v0.3.0/incubator-index.yaml`
 
-`appsody init appsodyhub/nodejs-express none`
+1. In the root of the application run
+   * `appsody init appsodyhub030/nodejs-express none`
 
-And then lauch the server again but this time through appsody.  The code will use the running mongodb docker instance started before.
-
-run `appsody run `
+1. And then lauch the server again but this time through appsody.  The code will use the running mongodb docker instance started before.
+   * `appsody run`
 
 Go back to  [http://localhost:3000]() Try to register a new user. Registering with the same email used in the original mode above should cause a message
 


### PR DESCRIPTION
using the latest 0.4 node.js express stack this sample gets the below exception on start. Maybe a problem with a newer level of Express. I updated the readme to use the 0.3.0 node.js stack so that app starts successfully.

```
[Container] [Thu Mar  5 16:04:46 2020] com.ibm.diagnostics.healthcenter.mqtt INFO: Connecting to broker localhost:1883
[Container] /project/server.js:35
[Container] app.use('/', userApp({
[Container]              ^
[Container] 
[Container] TypeError: userApp is not a function
[Container]     at Object.<anonymous> (/project/server.js:35:14)
[Container]     at Module._compile (internal/modules/cjs/loader.js:1158:30)
```